### PR TITLE
Fix unités

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 base carbone v16.1.csv
+.DS_store
 node_modules/
 public/co2.json
 

--- a/data/co2.yaml
+++ b/data/co2.yaml
@@ -41,15 +41,15 @@ douche . pomme de douche économe:
 eau:
   icônes: 💧
 eau . impact par litre froid:
-  unité: kgCO₂e/l
+  unité: kgCO2e/l
   formule: eau potable + traitement eau usée
   références:
     - http://www.bilans-ges.ademe.fr/documentation/UPLOAD_DOC_FR/index.htm?boissons.htm
 eau . impact par litre froid . eau potable:
-  unité: kgCO₂e/l
+  unité: kgCO2e/l
   formule: 0.000132
 eau . impact par litre froid . traitement eau usée:
-  unité: kgCO₂e/l
+  unité: kgCO2e/l
   formule: 0.000262
 chauffage:
   icônes: 🔥

--- a/data/piscine.yaml
+++ b/data/piscine.yaml
@@ -10,7 +10,7 @@ piscine . empreinte:
   catégorie: logement
   icônes: 🏠🏊
   titre: Une piscine privée
-  unité: kgCO₂e
+  unité: kgCO2e
   formule:
     somme:
       - empreinte eau froide
@@ -45,7 +45,7 @@ piscine . empreinte:
 
 piscine . traitement chimique:
   formule: empreinte chlore * masse de chlore
-  unité: kgCO₂e
+  unité: kgCO2e
   note: |
     Sur la base d'hypothèses sourcées dans les références de la variable "masse de chlore", pour l'instant dans le but d'obtenir un premier ordre de grandeur, on assimile toutes les matières chimiques utilisées dans une piscine au chlore.
 
@@ -55,7 +55,7 @@ piscine . traitement chimique:
 
 piscine . empreinte chlore:
   formule: 0.740
-  unité: kgCO₂e/kg
+  unité: kgCO2e/kg
   note: Nous prenons l'empreinte du Cl2, chlore gazeux liquéfié dans le document en référence ci-dessous.
   références:
     - https://www.oieau.org/eaudoc/system/files/documents/44/224151/224151_doc.pdf?page=31
@@ -86,7 +86,7 @@ piscine . chauffage . prorata période:
 piscine . chauffage:
   applicable si: eau chauffée
   formule: énergie * empreinte électricité * prorata période
-  unité: kgCO₂e
+  unité: kgCO2e
   note: |
     > D’autant plus qu’une piscine chauffée utilisée sans excès consomme normalement dans les 11 475kWh par année.
 
@@ -136,7 +136,7 @@ piscine . volume:
 
 piscine . pompe de filtrage:
   formule: puissance * utilisation . heures * empreinte électricité
-  unité: kgCO₂e
+  unité: kgCO2e
 
 piscine . pompe de filtrage . puissance:
   formule: 0.75
@@ -153,7 +153,7 @@ piscine . pompe de filtrage . utilisation . mois d'activité:
   question: Combien de mois par an utilisez-vous votre piscine ?
   unité: mois
 piscine . empreinte électricité:
-  unité: kgCO₂e/kWh
+  unité: kgCO2e/kWh
   formule: 0.0599
   description: Intensité moyenne du mix électrique français 2020 base carbone ADEME.
   note: Il serait peut-être pertinent de prendre l'empreinte du mix sur les mois d'utilisation de la piscine, l'hiver étant aujourd'hui le plus émetteur en France, et le moment le moins probable pour l'utilisation de la piscine.
@@ -166,14 +166,14 @@ piscine . construction:
 empreinte construction logement:
   titre: Construction logement neuf béton et parpaing
   formule: 600
-  unité: kgCO₂e/m²
+  unité: kgCO2e/m2
   note: Comme précisé dans la source "Guide animateur Inventons nos Vies Bas Carbone", la valeur de 600 est un ordre de grandeur très incertain.
   références:
     Inventons nos vies bas carbone: https://d3n8a8pro7vhmx.cloudfront.net/resistanceclimatique/pages/115/attachments/original/1616151401/20210228_guide_de_l'animateur_kit_INVBC.pdf?1616151401#page=82
 
 piscine . construction . empreinte théorique:
   formule: empreinte construction logement * surface
-  unité: kgCO₂e
+  unité: kgCO2e
   note: |
     Pour estimer l'empreinte de la construction d'une piscine, nous prenons celle connue pour la construction d'une maison en béton.
 

--- a/data/piscine.yaml
+++ b/data/piscine.yaml
@@ -61,7 +61,7 @@ piscine . empreinte chlore:
     - https://www.oieau.org/eaudoc/system/files/documents/44/224151/224151_doc.pdf?page=31
 
 piscine . masse de chlore:
-  formule: (150 + 20 + 30 + 30) / (35 / 5)
+  formule: (150 € + 20 € + 30 € + 30 €) / (35 € / 5 kg)
   unité: kg
   description: |
     > Si vous optez pour un traitement au chlore, vous devrez compter sur un budget annuel d’environ 150 € de chlore, 20 € de produit floculant, 30 € de produit anticalcaire, et enfin 30 € de produit pour rééquilibrer le pH, ce qui correspond à un budget annuel d’environ 230 €
@@ -118,7 +118,7 @@ piscine . empreinte eau froide:
 piscine . surface:
   question: Quelle est la surface de votre piscine ?
   par défaut: 32
-  unité: m²
+  unité: m2
   note: |
     Par défaut, 8x4m, donc 32m²
     > Du très classique rectangle 8X4 mètres aux piscines de taille plus modeste 7×3,5 m, ou plus imposante, 9×4,5m et plus, il existe nombre de déclinaisons possibles. Une piscine de  8 m X 4 m semble suffisante pour un usage familial tout en limitant l’entretien et le volume d’eau à traiter. C’est un bon compromis prix/surface.
@@ -131,8 +131,9 @@ piscine . profondeur:
   note: Nous partons sur une profondeur moyenne d'eau de 1m50, par exemple une pente linéaire de 1m à 2m.
 
 piscine . volume:
-  formule: profondeur * surface * 1000
+  formule: profondeur * surface * 1000 l/m3
   unité: l
+
 piscine . pompe de filtrage:
   formule: puissance * utilisation . heures * empreinte électricité
   unité: kgCO₂e
@@ -182,7 +183,6 @@ piscine . construction . empreinte théorique:
 
 piscine . construction . durée de vie:
   formule: 30
-  unité: ans
   note: |
     Nous avons dans un premier temps pris cette estimation, qui semble un peu basse pour le béton (qui est estimé davantage à 40 ans), mais plutôt réaliste pour le reste des équipements. C'est un paramètre à faire évoluer au besoin.
 
@@ -196,7 +196,7 @@ piscine . construction . empreinte empirique:
       - divers chantier
       - abri
   note: |
-    Les chiffres de cet espace de nom proviennent pour l'essentiel du calcul [présenté sur cette feuille A4](https://user-images.githubusercontent.com/1177762/245216468-760f16f8-59f4-447f-a1e5-862fcdb08980.png). 
+    Les chiffres de cet espace de nom proviennent pour l'essentiel du calcul [présenté sur cette feuille A4](https://user-images.githubusercontent.com/1177762/245216468-760f16f8-59f4-447f-a1e5-862fcdb08980.png).
 
 piscine . construction . divers chantier:
   formule:
@@ -251,14 +251,14 @@ piscine . construction . étanchéité . liner:
 
 piscine . construction . étanchéité . liner . empreinte PVC:
   formule: 0.350
-  unité: kgCO2e/m²
+  unité: kgCO2e/m2
 
 piscine . construction . étanchéité . liner . quantité:
   formule: piscine . construction . durée de vie / durée de vie
 piscine . construction . étanchéité . liner . durée de vie:
   titre: Durée de vie du liner
   formule: 10
-  unité: ans
+
 piscine . construction . étanchéité . liner . surface:
   formule: type . surface . parallélépipède * correcteur surface type
 
@@ -276,10 +276,10 @@ piscine . construction . plage pierre:
 
 piscine . construction . empreinte pierre:
   formule: 0.128
-  unité: kgCO2e/m²
+  unité: kgCO2e/m2
 piscine . construction . surface plage:
   formule: 28
-  unité: m²
+  unité: m2
 piscine . construction . terrassement:
   formule: conso diesel * empreinte diesel
 piscine . construction . terrassement . empreinte diesel:
@@ -325,6 +325,7 @@ piscine . construction . béton . masse volumique:
     - https://www.toutsurlebeton.fr/le-ba-ba-du-beton/masse-volumique-du-beton-et-de-ses-constituants/
 piscine . construction . béton . type . volume:
   formule: volume parallélépipède + volume plage
+  unité: m3
 
 piscine . construction . béton . type . volume parallélépipède:
   formule: surface * épaisseur
@@ -340,14 +341,14 @@ piscine . type:
 
 piscine . type . surface:
   formule: 32
-  unité: m²
+  unité: m2
   description: La surface de la piscine réellement construite et utilisée comme base pour ce modèle.
   références:
     - https://twitter.com/ObjectifZero/status/1392179434900316165/photo/1
 
 piscine . type . surface . murs:
-  formule: 1.5 * (8 + 4 + 8 + 4)
-  unité: m²
+  formule: 1.5 m * (8 m + 4 m + 8 m + 4 m)
+  unité: m2
 
 piscine . type . surface . parallélépipède:
   formule: surface + murs
@@ -355,7 +356,7 @@ piscine . type . surface . parallélépipède:
     On considère une piscine de 8m x 4m x une profondeur moyenne de 1,5m (2 au bout et 1 à l'autre bout, descente linéaire).
 
     La surface de cette piscine type est de 32m² de fond ainsi que 36m² de murs.
-  unité: m²
+  unité: m2
 
 piscine . construction . abri:
   formule: 0

--- a/data/transport . ferry>.yaml
+++ b/data/transport . ferry>.yaml
@@ -40,7 +40,7 @@ empreinte du voyage:
     image: https://futur.eco/images/ferry.png
     exemples via suggestions: transport . ferry . distance aller . orthodromique
   formule: distance aller retour * empreinte par km volume
-  unité: kgCO₂e
+  unité: kgCO2e
 
 durée du voyage:
   question: Quelle est la durée de votre traversée ?

--- a/data/transport . ferry>.yaml
+++ b/data/transport . ferry>.yaml
@@ -10,7 +10,7 @@ vitesse:
   icônes: ⌚
   question: Quelle est la vitesse du ferry ?
   formule: vitesse en kmh / km par mille nautique
-  unité: mn / h
+  unité: noeud
   suggestions:
     lente: 12
     rapide: 18
@@ -121,7 +121,7 @@ empreinte totale moyenne:
 
 vitesse moyenne:
   formule: métrique / km par mille nautique
-  unité: mn / h
+  unité: noeud
 
 vitesse moyenne . métrique:
   titre: Vitesse moyenne ferry

--- a/data/transport . ferry>.yaml
+++ b/data/transport . ferry>.yaml
@@ -10,15 +10,17 @@ vitesse:
   icônes: ⌚
   question: Quelle est la vitesse du ferry ?
   formule: vitesse en kmh / km par mille nautique
-  unité: noeud
+  unité: mn / h
   suggestions:
-    lente: 12 noeud
-    rapide: 18 noeud
-    très rapide: 27 noeud
+    lente: 12
+    rapide: 18
+    très rapide: 27
 
 vitesse en kmh:
   formule: distance aller / durée du voyage . réelle
   par défaut: vitesse moyenne . métrique
+
+km par mille nautique: 1.852 km/mn
 
 vitesse trop élevée:
   type: notification
@@ -116,9 +118,10 @@ empreinte totale moyenne:
   formule: 576.48 kgCO2e/mn
   note: |
     Données greenferries 2020 tirées de Thetis-MRV 2020 https://mrv.emsa.europa.eu/#public/emission-report
+
 vitesse moyenne:
   formule: métrique / km par mille nautique
-  unité: noeud
+  unité: mn / h
 
 vitesse moyenne . métrique:
   titre: Vitesse moyenne ferry
@@ -201,20 +204,24 @@ volume passager:
 
 volume passager . communs:
   formule: volume communs / passagers
+
 volume passager . loisirs:
   applicable si: consommation de services
   formule: surface . loisirs * hauteur pont bas / passagers
+  unité: m3
 
 volume passager . siège:
   non applicable si: cabine
   titre: Un siège dans un dortoir
   formule: hauteur pont bas * surface . siège
+  unité: m3
 
 volume passager . voiture:
   applicable si: voiture
   formule: majoré / groupe
   note: |
     Ici nous décidons de ne pas voir la capacité en voiture et diviser la surface voiture par ce nombre, car les différentes zones de garage peuvent accomoder aussi bien des voitures que des camions.
+  unité: m3
 
 volume passager . voiture . majoré:
   titre: Volume garage voiture
@@ -255,25 +262,30 @@ surface . communs:
   description: |
     Cela inclut les escaliers, des places assises en salon hors bar ou restaurant, les couloirs intérieurs. Par convention, on n'inclut pas les surfaces extérieures non couvertes, sauf les espaces de loisir évidents : la piscine et les bars extérieurs.
   par défaut: 1466
+  unité: m2
 
 surface . loisirs:
   injecté: oui
   question: Quelle est la surface dédiée aux loisirs ?
   description: Restaurants, bars, salons, jeux, commerces, piscines, etc.
   par défaut: 4762
+  unité: m2
 
 hauteur moyenne garage:
   formule: (surface . garage . bas * hauteur pont bas + surface . garage . haut * hauteur pont haut) / surface . garage
+  unité: m
 
 surface . garage . bas:
   injecté: oui
   question: Quelle est la surface de garage bas du bateau ?
   par défaut: 2334
+  unité: m2
 
 surface . garage . haut:
   injecté: oui
   question: Quelle est la surface de garage haut du bateau ?
   par défaut: 11881
+  unité: m2
 
 surface . garage: bas + haut
 
@@ -281,18 +293,22 @@ surface . cabines:
   injecté: oui
   question: Quelle est la surface totale des cabines ?
   par défaut: 7356
+  unité: m2
 
 surface . sièges:
   injecté: oui
   question: Quelle est la surface totale des sièges ?
   par défaut: 1095
+  unité: m2
 
 volume passager . cabine partagée:
   applicable si: billet cabine
   formule: (cabines nécessaires * cabine) / groupe
+  unité: m3
 
 hauteur pont bas:
-  formule: 2.7m
+  formule: 2.7
+  unité: m
 
 hauteur pont haut:
   formule: hauteur pont bas * 2
@@ -306,10 +322,11 @@ surface:
 
 surface . cabine:
   formule: cabines / cabine . nombre
+  unité: m2
+
 surface . siège:
   formule: sièges / siège . nombre
-
-km par mille nautique: 1.852 km/mn
+  unité: m2
 
 billet cabine: cabine
 
@@ -375,7 +392,6 @@ groupe:
   icônes: 👥
   question: À combien voyagez-vous ?
   par défaut: 2
-  unité: personnes
   suggestions:
     seul: 1
     en couple: 2


### PR DESCRIPTION
Une PR pour fixer les erreurs d'unités de l'Engine :

- [x] Homogénéité des formules
- [x] kgCO₂e -> kgCO2e : je ne suis pas convaincu par la solution actuelle, à mon avis on ne souhaite pas corriger cette unité dans la mesure ou futures utilise majoritairement kgCO₂e. Mais NGC utilise exclusivement kgCO2e pour simplifier l'écriture du modèle. A mon avis il faudrait choisir entre les 2 .. Qu'en pensez vous @EmileRolley @laem ? -> Table de constantes dans Publicodes ?